### PR TITLE
Fix cleanup #87

### DIFF
--- a/src/main/java/javamop/output/combinedaspect/event/ThreadStatusMonitor.java
+++ b/src/main/java/javamop/output/combinedaspect/event/ThreadStatusMonitor.java
@@ -266,23 +266,9 @@ public class ThreadStatusMonitor extends EndThread{
     @Override
     public String printAdvices() {
         String ret = "";
-        ret += printDataStructures();
-        ret += "\n";
-        ret += printContainsBlockedThread();
-        ret += "\n";
-        ret += printContainsThread();
-        ret += "\n";
-        ret += printAdviceForThreadWithRunnable();
-        ret += "\n";
-        ret += printAdviceForEndThread();
-        ret += "\n";
-        ret += printAdviceForEndRunnable();
-        ret += "\n";
-        ret += printAdviceForMainEnd();
-        ret += "\n";
+        ret += printMethodCallForMainStart();
         ret += printAdviceForNewThread();
         ret += "\n";
-
         return ret;
     }
     


### PR DESCRIPTION
@xiaohe27 @kheradmand @yzhang90 Please review this change.

This change fixes a bug introduced in #87 . Please see my comment there. Essentially since translate2RV is always true now, I should retain the code in the else branch rather than in the if branch.

I will write some integration test for EnforceMOP once the problem of EnforceMOP in RVMonitor is resolved (see RV-Monitor issue # 100). So we can prevent it from being introduced in the first place.

Thanks,

Qingzhou
