### PR TITLE
update readme to remove some duplicated warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ the src/README file.
 **Note:** The rest of this document assumes that you have followed all
 the instructions in INSTALL.md and updated your CLASSPATH and PATH
 environment variables according to the Prerequisites section in that
-file.  In addition, please make sure the dependencies mentioned in
-INSTALL.md remain on the CLASSPATH whenever you modify or overwrite
-the CLASSPATH.
+file. In addition, we also assume that "." is on your CLASSPATH. Last
+but not least, please be cautious whenever you modify or override the
+CLASSPATH as it might break the prerequisites of JavaMOP.
 
 ## Usage
 
@@ -272,10 +272,6 @@ monitoring multiple properties simultaneously.
 
 #### Weaving the code using AspectJ Compiler (ajc)
 
-Before weaving the code, make sure that you have already installed ajc
-and RV-Monitor. Please refer to INSTALL.md for prerequisites of using
-JavaMOP (installing JRE, AJC and RV-Monitor).
-
 To weave the target program with the generated monitoring library, run
 the following command:
 
@@ -298,21 +294,17 @@ the ```<target directory>```.
 
 (For more information on ajc options, type ```ajc -help``` for help)
 
-**Note:** As mentioned before, certain files (see Prerequisites in
-INSTALL.md) must be present on the java class path.  If you have
-additional dependencies and you want to add them with `-cp` (or
-`-classpath`) option, please make sure that those files remain on the
-classpath.
+**Note:** If you have additional dependencies, then you may add them 
+with `-cp` (or `-classpath`) option. Please be careful when using this
+option because it will override your CLASSPATH. This suggestion applies 
+to both ```ajc``` and ```java```.
 
 #### Running the Weaved Code
 To run the weaved program, simply type:
 
 ```java Main```
 
-where `Main` is the entry point to the application.
-
-**Note:** Again, make sure that pre-requisites are in the java class
-path specially when you use `-cp` (or `-classpath`) option.
+where `Main` is assumed to be the entry point to the application.
 
 ### Troubleshooting
 


### PR DESCRIPTION
As suggested by @Cansu and @kheradmand , too many similar warnings may have opposite effects: users may become quite familiar with the warnings so that they will not treat the warnings seriously when they feel they can guess the contents of the warnings. Now I only preserve the **Note** in the 'Install' section. @kheradmand @seriousamlqz please review.
