### PR TITLE
re-enable the function of reading dir of mop files

### DIFF
--- a/examples/agent/many/rvm/output/readme.txt
+++ b/examples/agent/many/rvm/output/readme.txt
@@ -1,0 +1,1 @@
+This is a folder used in testing phase only.

--- a/src/main/java/javamop/JavaMOPMain.java
+++ b/src/main/java/javamop/JavaMOPMain.java
@@ -54,6 +54,20 @@ public final class JavaMOPMain {
     private static final String AJ_FILE_SUFFIX = "MonitorAspect.aj";
 
     /**
+     * Because the JavaMOP's main method may be invoked multiple times to handle
+     * multiple input files, we need to reset the static variables at the beginning
+     * of execution.
+     */
+    private static void init() {
+//        specifiedAJName = false;
+//        isJarFile = false;
+//        jarFilePath = null;
+//        empty_advicebody = false;
+        listFilePairs.clear();
+        listRVMFiles.clear();
+    }
+
+    /**
      * Determine where to place the JavaMOP output files, if it is not decided elsewhere. If all
      * the parameter files are in the same directory, use that directory. Otherwise, use the
      * directory that JavaMOP is executing in.
@@ -282,6 +296,10 @@ public final class JavaMOPMain {
             options.merge = true;
         }
 
+        init();
+        //The spec files in directories have already been handled, so reset env
+        // to avoid deleting the same file twice...
+
         //ensure every spec file has a valid name (according to Java's identifier naming convention)
         areValidNames(specFiles);
         if (options.merge) {
@@ -359,6 +377,8 @@ public final class JavaMOPMain {
      * @param args Configuration options and input files for JavaMOP.
      */
     public static void main(String[] args) {
+        init();
+
         options = new JavaMOPOptions();
         JCommander jc;
         try {
@@ -390,6 +410,12 @@ public final class JavaMOPMain {
                 e.printStackTrace();
         }
 
+        if (listFilePairs.size() == 0) {
+            //it indicates there is no output generated
+            //perhaps the input is a directory and all work has been done
+            System.out.println("Done.");
+            return;
+        }
         // replace mop with rvm and call rv-monitor
         List<String> rvArgs = new ArrayList<String>();
         for (int j = 0; j < args.length; j++) {

--- a/src/main/java/javamop/JavaMOPMain.java
+++ b/src/main/java/javamop/JavaMOPMain.java
@@ -269,14 +269,13 @@ public final class JavaMOPMain {
      * @param path Common prefix to all the paths in {@code files}.
      */
     public static void process(String[] files, String path) throws MOPException, IOException {
-        areValidNames(files);
-
         ArrayList<File> specFiles = collectFiles(files, path);
-
         if(options.aspectname != null && files.length > 1){
             options.merge = true;
         }
 
+        //ensure every spec file has a valid name (according to Java's identifier naming convention)
+        areValidNames(specFiles);
         if (options.merge) {
             System.out.println("-Processing " + specFiles.size()
             + " specification(s)");
@@ -322,9 +321,9 @@ public final class JavaMOPMain {
     }
 
     //If any input mop file does not have a valid name, then exit.
-    private static void areValidNames(String[] files) {
-        for (int i = 0; i < files.length; i++) {
-            String curName = Tool.getFileName(files[i]);
+    private static void areValidNames(ArrayList<File> files) {
+        for (int i = 0; i < files.size(); i++) {
+            String curName = Tool.getFileName(files.get(i).getPath());
             if (!curName.matches("[a-zA-Z_]\\p{Alnum}*")) {
                 System.err.println("The mop name " + curName + " is not valid!");
                 System.exit(1);
@@ -372,9 +371,6 @@ public final class JavaMOPMain {
                 "!/javamop/JavaMOPMain.class".length());
             jarFilePath = Tool.polishPath(jarFilePath);
         }
-
-        SpecFilter filter = null;
-
         // Generate .rvm files and .aj files
         try {
             process(options.files);

--- a/src/main/java/javamop/util/MOPFileVisitor.java
+++ b/src/main/java/javamop/util/MOPFileVisitor.java
@@ -1,0 +1,60 @@
+package javamop.util;
+
+import javamop.JavaMOPMain;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+
+import static java.nio.file.FileVisitResult.CONTINUE;
+
+/**
+ * Created by hx312 on 25/04/2015.
+ */
+public class MOPFileVisitor extends SimpleFileVisitor<Path> {
+    private Path inputDirPath = null;
+    private final Path outputDirPath;
+
+    public MOPFileVisitor(Path outputDirPath) {
+        this.outputDirPath = outputDirPath;
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attributes)
+        throws IOException {
+        if (this.inputDirPath == null) {
+            this.inputDirPath = dir;
+        } else {
+            Files.createDirectories(this.outputDirPath.resolve(this.inputDirPath.relativize(dir)));
+        }
+        return CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+        String fileName = String.valueOf(file.getFileName());
+        if (fileName.endsWith(".mop")) {
+            Path relativePath = inputDirPath.relativize(file);
+            System.out.println(relativePath);
+            //when the mop file is visited, its corresponding folder must have already been
+            //created in the output directory by the above preVisitDirectory method.
+            Path outputPath = this.outputDirPath.resolve(this.inputDirPath.relativize(file))
+                                .getParent();
+            JavaMOPMain.main(new String[]{file.toFile().getAbsolutePath(),
+                            "-d", outputPath.toFile().getAbsolutePath()});
+        }
+        return CONTINUE;
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path inP = Paths.get("A:\\UIUC-SW\\javamop\\target\\release\\javamop\\javamop\\examples" +
+                "\\agent\\many\\rvm");
+        Path outP = Paths.get("A:\\UIUC-SW\\javamop\\target\\release\\javamop\\javamop\\examples" +
+                "\\agent\\many\\testOut");
+        MOPFileVisitor mopFileVisitor = new MOPFileVisitor(outP);
+
+        Files.walkFileTree(inP, mopFileVisitor);
+
+    }
+}

--- a/src/main/java/javamop/util/MOPFileVisitor.java
+++ b/src/main/java/javamop/util/MOPFileVisitor.java
@@ -21,12 +21,14 @@ public class MOPFileVisitor extends SimpleFileVisitor<Path> {
     }
 
     @Override
-    public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attributes)
+    public FileVisitResult preVisitDirectory(final Path dir,
+                                   final BasicFileAttributes attributes)
         throws IOException {
         if (this.inputDirPath == null) {
             this.inputDirPath = dir;
         } else {
-            Files.createDirectories(this.outputDirPath.resolve(this.inputDirPath.relativize(dir)));
+            Files.createDirectories(this.outputDirPath.resolve
+                    (this.inputDirPath.relativize(dir)));
         }
         return CONTINUE;
     }
@@ -35,26 +37,15 @@ public class MOPFileVisitor extends SimpleFileVisitor<Path> {
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
         String fileName = String.valueOf(file.getFileName());
         if (fileName.endsWith(".mop")) {
-            Path relativePath = inputDirPath.relativize(file);
-            System.out.println(relativePath);
-            //when the mop file is visited, its corresponding folder must have already been
-            //created in the output directory by the above preVisitDirectory method.
-            Path outputPath = this.outputDirPath.resolve(this.inputDirPath.relativize(file))
-                                .getParent();
+            //when the mop file is visited, its corresponding folder
+            // must have already been created in the output directory
+            // by the above preVisitDirectory method.
+            Path outputPath = this.outputDirPath.resolve
+                    (this.inputDirPath.relativize(file)).getParent();
             JavaMOPMain.main(new String[]{file.toFile().getAbsolutePath(),
                             "-d", outputPath.toFile().getAbsolutePath()});
         }
         return CONTINUE;
     }
 
-    public static void main(String[] args) throws IOException {
-        Path inP = Paths.get("A:\\UIUC-SW\\javamop\\target\\release\\javamop\\javamop\\examples" +
-                "\\agent\\many\\rvm");
-        Path outP = Paths.get("A:\\UIUC-SW\\javamop\\target\\release\\javamop\\javamop\\examples" +
-                "\\agent\\many\\testOut");
-        MOPFileVisitor mopFileVisitor = new MOPFileVisitor(outP);
-
-        Files.walkFileTree(inP, mopFileVisitor);
-
-    }
 }

--- a/src/test/java/baseaspect/BaseAspectIT.java
+++ b/src/test/java/baseaspect/BaseAspectIT.java
@@ -68,7 +68,7 @@ public class BaseAspectIT {
                     javaOutputPrefix + File.separator + javaOutputPrefix + ".java", ".." +
                             File.separator + this.ajName);
 
-            helper_default.testCommand(javaOutputPrefix, javaOutputPrefix, false, true,
+            helper_default.testCommand(javaOutputPrefix, javaOutputPrefix, false, true, false,
                     "java", "-cp", classpath, javaOutputPrefix);
 
 
@@ -113,7 +113,7 @@ public class BaseAspectIT {
                     "org.aspectj.tools.ajc.Main", "-1.6", "-d", prefix1,
                     prefix1 + File.separator + prefix1 + ".java", ".." + File.separator + ajName);
 
-            helper_userSpecified.testCommand(prefix1, prefix1, false, true,
+            helper_userSpecified.testCommand(prefix1, prefix1, false, true, false,
                     "java", "-cp", classpath, prefix1);
 
             //Second, test whether HasNext_1.java was NOT instrumented as usual (the pointcuts within that path
@@ -123,7 +123,7 @@ public class BaseAspectIT {
                     "org.aspectj.tools.ajc.Main", "-1.6", "-d", prefix2,
                     prefix2 + File.separator + prefix2 + ".java", ".." + File.separator + ajName);
 
-            helper_userSpecified.testCommand(prefix2, prefix2, false, true,
+            helper_userSpecified.testCommand(prefix2, prefix2, false, true, false,
                     "java", "-cp", classpath, prefix2);
 
 

--- a/src/test/java/examples/ExamplesIT.java
+++ b/src/test/java/examples/ExamplesIT.java
@@ -1,15 +1,14 @@
 // Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
 package examples;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.Test;
-
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  * JUnit test case to run through select program examples. Based on examples/run and examples/runall.
@@ -55,7 +54,8 @@ public class ExamplesIT {
             helper.testCommand(null, false, true, "java", "-cp", specificClasspath,
                 "org.aspectj.tools.ajc.Main", "-1.6", "-d",  subcasePathI, subcasePathI + 
                 File.separator + subcasePathI + ".java", testName + "MonitorAspect.aj");
-            helper.testCommand(subcasePathI, subcasePathI, false, true, "java", "-cp", specificClasspath,
+            helper.testCommand(subcasePathI, subcasePathI, false, true, false,"java", "-cp",
+                    specificClasspath,
                 subcasePathI);
             helper.deleteFiles(true, subcasePathI + File.separator + subcasePathI + ".actual.err", 
                 subcasePathI + File.separator + subcasePathI + ".actual.out");

--- a/src/test/java/examples/ReadDirIT.java
+++ b/src/test/java/examples/ReadDirIT.java
@@ -1,6 +1,7 @@
 package examples;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -15,16 +16,36 @@ public class ReadDirIT {
     private final TestHelper helper = new TestHelper(path);
 
     @Test
-    public void testDirAsInput() throws Exception{
+    public void testDirAsInput() throws Exception {
         String command = System.getProperty("user.dir") + File.separator + "bin" + File.separator + "javamop";
         if (SystemUtils.IS_OS_WINDOWS) {
             command += ".bat";
         }
+
+        String outputDir = this.path + File.separator + ".." + File.separator
+                + "output" + File.separator;
+        File safeFileAJ = new File(outputDir + "SafeFileMonitorAspect.aj");
+        File safeFileWriterAJ = new File(outputDir + "SafeFileWriterMonitorAspect.aj");
+
         try {
             helper.testCommand("output", "cfg", false, true, true, command, ".." + File.separator +
                     "cfg -d .");
+
+
+            Assert.assertTrue("SafeFileMonitorAspect.aj does not exist.",
+                    safeFileAJ.exists());
+
+            Assert.assertTrue("SafeFileWriterMonitorAspect.aj does not exist.",
+                    safeFileWriterAJ.exists());
         } finally {
-//            helper.deleteFiles(true, "");
+            boolean succ1 = safeFileAJ.delete();
+            boolean succ2 = safeFileWriterAJ.delete();
+
+            Assert.assertTrue("Fail to delete SafeFileMonitorAspect.aj",
+                    succ1);
+
+            Assert.assertTrue("Fail to delete SafeFileWriterMonitorAspect.aj",
+                    succ2);
         }
     }
 }

--- a/src/test/java/examples/ReadDirIT.java
+++ b/src/test/java/examples/ReadDirIT.java
@@ -1,0 +1,30 @@
+package examples;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * Created by xiaohe on 5/6/15.
+ */
+public class ReadDirIT {
+    private final String path = "examples" + File.separator + "agent" + File.separator + "many"
+            + File.separator + "rvm" + File.separator + "cfg";
+
+    private final TestHelper helper = new TestHelper(path);
+
+    @Test
+    public void testDirAsInput() throws Exception{
+        String command = System.getProperty("user.dir") + File.separator + "bin" + File.separator + "javamop";
+        if (SystemUtils.IS_OS_WINDOWS) {
+            command += ".bat";
+        }
+        try {
+            helper.testCommand("output", "cfg", false, true, true, command, ".." + File.separator +
+                    "cfg -d .");
+        } finally {
+//            helper.deleteFiles(true, "");
+        }
+    }
+}

--- a/src/test/java/examples/TestHelper.java
+++ b/src/test/java/examples/TestHelper.java
@@ -57,7 +57,7 @@ public class TestHelper {
      */
     public void testCommand(String expectedFilePrefix, boolean ignoreOrder, boolean mustSucceed,
                             String... commands) throws Exception {
-        testCommand("", expectedFilePrefix, ignoreOrder, mustSucceed, commands);
+        testCommand("", expectedFilePrefix, ignoreOrder, mustSucceed, false, commands);
     }
 
     /**
@@ -67,11 +67,13 @@ public class TestHelper {
      * @param expectedFilePrefix the prefix for the expected files, or null if output is not checked.
      * @param ignoreOrder when comparing contents of two files, whether to ignore the order of lines or not
      * @param mustSucceed if the program's return code must be {@code 0}.
+     * @param onlyCheckStdErr Only check whether there is error occurring during execution.
      * @param command  list of arguments describing the system command to be executed.
      * @throws Exception
      */
     public void testCommand(String relativePath, String expectedFilePrefix, boolean ignoreOrder,
-                            boolean mustSucceed, String... command) throws Exception {
+                            boolean mustSucceed, boolean onlyCheckStdErr, String... command) throws
+            Exception {
         ProcessBuilder processBuilder = new ProcessBuilder(command).inheritIO();
         processBuilder.directory(new File(basePathFile.toString() + File.separator + relativePath));
         processBuilder.environment().put("CLASSPATH", processBuilder.environment().get("CLASSPATH") + File.pathSeparator
@@ -105,7 +107,7 @@ public class TestHelper {
         if(mustSucceed) {
             Assert.assertEquals("Expected no error during" + Arrays.toString(command) + ".", 0, returnCode);
         }
-        if (expectedFilePrefix != null) {
+        if (expectedFilePrefix != null && !onlyCheckStdErr) {
             if (!ignoreOrder) {
                 assertEqualFiles(expectedOutFile, actualOutFile);
                 assertEqualFiles(expectedErrFile, actualErrFile);

--- a/src/test/java/examples/TestHelper.java
+++ b/src/test/java/examples/TestHelper.java
@@ -100,8 +100,12 @@ public class TestHelper {
             }
 
         }
-        processBuilder.redirectError(new File(actualErrFile));
-        processBuilder.redirectOutput(new File(actualOutFile));
+
+        if (!onlyCheckStdErr) {
+            processBuilder.redirectError(new File(actualErrFile));
+            processBuilder.redirectOutput(new File(actualOutFile));
+        }
+
         Process process = processBuilder.start();
         int returnCode = process.waitFor();
         if(mustSucceed) {


### PR DESCRIPTION
The function of reading all mop files for a dir was disabled unexpectedly in the last commit, it comes back now.

Seems that the structure of input mop files will not be reserved when the output files are generated in the output directory.
Some more work will be done to keep the folder structures.
