### PR TITLE
fix a classpath problem in windows

### DIFF
--- a/src/main/java/javamop/agent/SeparateAgentGenerator.java
+++ b/src/main/java/javamop/agent/SeparateAgentGenerator.java
@@ -67,7 +67,8 @@ public final class SeparateAgentGenerator {
 
         // Step 2: Compile the generated AJC File (allMonitorAspect.aj)
         // Change aspect name
-        String completeClassPath = baseClasspath + File.pathSeparator + classDir.getAbsolutePath();
+        String completeClassPath = "\"" + baseClasspath + File.pathSeparator + 
+			classDir.getAbsolutePath() + "\"";
         final int ajcReturn = runCommandDir(outputDir, verbose, "java", "-cp", completeClassPath,
                 "org.aspectj.tools.ajc.Main", "-1.6", "-d", agentDir.getAbsolutePath(),
                 "-outxml", agentAspect.getAbsolutePath());


### PR DESCRIPTION
Fix an issue in classpath setting of javamopagent:
make sure that the classpath used in enclosed in double quotes.
This can fix the problem caused by white spaces inside classpath