### PR TITLE
Remove rvm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,73 +84,7 @@
             <version>1.35</version>
         </dependency>
     </dependencies>
-    <!-- Profile for installing RV-Monitor dependency with no repo access (will attempt only when rvMonitoBase property is provided) -->
-    <profiles>
-        <profile>
-            <id>install-rv-monitor-locally</id>
-            <activation>
-                <property>
-                    <name>rvMonitorBase</name>
-                </property>
-            </activation>
-            <build>
-                <!-- Execute iterator plugin if RV-Monitor is to be resolved -->
-                <plugins>
-                    <plugin>
-                        <groupId>com.soebes.maven.plugins</groupId>
-                        <artifactId>iterator-maven-plugin</artifactId>
-                        <version>0.2</version>
-                        <executions>
-                            <execution>
-                                <phase>validate</phase>
-                                <goals>
-                                    <goal>executor</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>true</skip>
-                                    <items>
-                                        <!-- List of proprietary RV-Monitor dependencies 
-                                        (as file name from base of lib/ directory with no jar extension)-->
-                                        <item>rv-monitor</item>
-                                        <item>rv-monitor-rt</item>
-                                        <item>logicrepository</item>
-                                        <item>plugins/cfg</item>
-                                        <item>plugins/ere</item>
-                                        <item>plugins/fsm</item>
-                                        <item>plugins/ltl</item>
-                                        <item>plugins/pda</item>
-                                        <item>plugins/po</item>
-                                        <item>plugins/ptcaret</item>
-                                        <item>plugins/ptltl</item>
-                                        <item>plugins/srs</item>
-                                        <item>plugins/tfsm</item>
-                                    </items>
-                                    <pluginExecutors>
-                                        <pluginExecutor>
-                                            <plugin>
-                                                <groupId>org.codehaus.mojo</groupId>
-                                                <artifactId>exec-maven-plugin</artifactId>
-                                                <version>1.2.1</version>
-                                            </plugin>
-                                            <goal>exec</goal>
-                                            <configuration>
-                                                <executable>mvn</executable>
-                                                <arguments>
-                                                    <!-- Ensure v2.5.2 of install plugin is used (old versions don't support install from Jar's POM) -->
-                                                    <argument>org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file</argument>
-                                                    <argument>-Dfile=${rvMonitorBase}/lib/@item@.jar</argument>
-                                                </arguments>
-                                            </configuration>
-                                        </pluginExecutor>
-                                    </pluginExecutors>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/javamop/parser/JavaParserAdapter.java
+++ b/src/main/java/javamop/parser/JavaParserAdapter.java
@@ -1,8 +1,8 @@
 // Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
 package javamop.parser;
 
-import com.runtimeverification.rvmonitor.core.ast.*;
-import com.runtimeverification.rvmonitor.core.parser.RVParser;
+import javamop.parser.rvm.core.ast.*;
+import javamop.parser.main_parser.RVParser;
 import javamop.parser.ast.ImportDeclaration;
 import javamop.parser.ast.PackageDeclaration;
 import javamop.parser.ast.body.BodyDeclaration;

--- a/src/main/java/javamop/parser/rvm/core/ast/Event.java
+++ b/src/main/java/javamop/parser/rvm/core/ast/Event.java
@@ -1,0 +1,94 @@
+package javamop.parser.rvm.core.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An event monitored in the output program.
+ */
+public class Event {
+
+    private final List<String> modifiers;
+    private final String name;
+    private final List<String> definitionModifiers;
+    private final String definition;
+    private final String pointcut;
+    private final String action;
+
+    /**
+     * Construct an Event out of its component parts.
+     *
+     * @param modifiers  Strings that change the meaning of the event.
+     * @param name       The name of the event to monitor.
+     * @param definition The descrption of what the event is on, e.g. its parameters.
+     * @param action     The action to take on encountering the event.
+     */
+    public Event(final List<String> modifiers, final String name,
+                 final List<String> definitionModifiers, final String definition,
+                 final String pointcut, final String action) {
+        this.modifiers = Collections.unmodifiableList(new ArrayList<String>(
+                modifiers));
+        this.name = name;
+        this.definitionModifiers = Collections
+                .unmodifiableList(new ArrayList<String>(definitionModifiers));
+        this.definition = definition;
+        this.pointcut = pointcut;
+        this.action = action;
+    }
+
+    /**
+     * Strings that affect the meaning of the event.
+     *
+     * @return An unmodifiable list of strings.
+     */
+    public List<String> getModifiers() {
+        return modifiers;
+    }
+
+    /**
+     * The name of the event.
+     *
+     * @return The event's name, which is also used in the logic states.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Modifiers after the event, but before the event definition/parameters.
+     *
+     * @return The event modifiers applying to the parameters.
+     */
+    public List<String> getDefinitionModifiers() {
+        return definitionModifiers;
+    }
+
+    /**
+     * The event's parameters.
+     *
+     * @return The parameters of the event, described in a language-specific
+     * way.
+     */
+    public String getDefinition() {
+        return definition;
+    }
+
+    /**
+     * The language-specific pointcut describing where the event occurs. May be
+     * empty or just whitespace.
+     */
+    public String getPointcut() {
+        return pointcut;
+    }
+
+    /**
+     * Language-specific code to take on encountering the event.
+     *
+     * @return Code in the target language to run on encountering the event.
+     */
+    public String getAction() {
+        return action;
+    }
+
+}

--- a/src/main/java/javamop/parser/rvm/core/ast/MonitorFile.java
+++ b/src/main/java/javamop/parser/rvm/core/ast/MonitorFile.java
@@ -1,0 +1,52 @@
+package javamop.parser.rvm.core.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A RVM input file, which contains one preamble and at least one specification.
+ *
+ * @author A. Cody Schuffelen
+ */
+public class MonitorFile {
+
+    private final String preamble;
+    private final List<Specification> specifications;
+
+    /**
+     * Construct a MonitorFile out of the preamble and some specifications.
+     *
+     * @param preamble Declarations at the beginning of the file, e.g. imports.
+     */
+    public MonitorFile(final String preamble,
+                       final List<Specification> specifications) {
+        this.preamble = preamble;
+        if (specifications.size() == 0) {
+            throw new RuntimeException(
+                    "RVM files must have at least one specification.");
+        }
+        this.specifications = Collections
+                .unmodifiableList(new ArrayList<Specification>(specifications));
+    }
+
+    /**
+     * Language-specific declarations that go at the top of the file, e.g.
+     * includes, imports.
+     *
+     * @return Language-specific top of the file declarations.
+     */
+    public String getPreamble() {
+        return preamble;
+    }
+
+    /**
+     * An unmodifiable list of the specifications in the monitoring file.
+     *
+     * @return A list of the specifications.
+     */
+    public List<Specification> getSpecifications() {
+        return specifications;
+    }
+
+}

--- a/src/main/java/javamop/parser/rvm/core/ast/Property.java
+++ b/src/main/java/javamop/parser/rvm/core/ast/Property.java
@@ -1,0 +1,60 @@
+package javamop.parser.rvm.core.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A logic property in the specification with handlers.
+ *
+ * @author A. Cody Schuffelen
+ */
+public class Property {
+
+    private final String name;
+    private final String syntax;
+    private final List<PropertyHandler> handlers;
+
+    /**
+     * Construct the Property out of its component elements.
+     *
+     * @param name     The logic name of the property (e.g. ere, fsm).
+     * @param syntax   The code describing the property.
+     * @param handlers Handlers used to respond to states in the property.
+     */
+    public Property(final String name, final String syntax,
+                    final List<PropertyHandler> handlers) {
+        this.name = name;
+        this.syntax = syntax;
+        this.handlers = Collections
+                .unmodifiableList(new ArrayList<PropertyHandler>(handlers));
+    }
+
+    /**
+     * The logic name of the property.
+     *
+     * @return The name of the logic repository plugin used in the property.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * The expression describing the property.
+     *
+     * @return The property logic formula.
+     */
+    public String getSyntax() {
+        return syntax;
+    }
+
+    /**
+     * An unmodifiable list of the handlers for the different states of the
+     * property.
+     *
+     * @return A list of state handlers.
+     */
+    public List<PropertyHandler> getHandlers() {
+        return handlers;
+    }
+}

--- a/src/main/java/javamop/parser/rvm/core/ast/PropertyHandler.java
+++ b/src/main/java/javamop/parser/rvm/core/ast/PropertyHandler.java
@@ -1,0 +1,41 @@
+package javamop.parser.rvm.core.ast;
+
+/**
+ * A handler to invoke on reaching a specific state in a logic property.
+ *
+ * @author A. Cody Schuffelen
+ */
+public class PropertyHandler {
+
+    private final String state;
+    private final String action;
+
+    /**
+     * Construct a PropertyHandler out of its component elements.
+     *
+     * @param state  The state to invoke the handler on.
+     * @param action The language-specific action to take on entering the state.
+     */
+    public PropertyHandler(final String state, final String action) {
+        this.state = state;
+        this.action = action;
+    }
+
+    /**
+     * The state to apply the action to.
+     *
+     * @return The String name of the state this handler is related to.
+     */
+    public String getState() {
+        return state;
+    }
+
+    /**
+     * The language-specific action to apply on reaching the state.
+     *
+     * @return Language-specific code for the action.
+     */
+    public String getAction() {
+        return action;
+    }
+}

--- a/src/main/java/javamop/parser/rvm/core/ast/Specification.java
+++ b/src/main/java/javamop/parser/rvm/core/ast/Specification.java
@@ -1,0 +1,102 @@
+package javamop.parser.rvm.core.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A RVM property specification.
+ *
+ * @author A. Cody Schuffelen
+ */
+public class Specification {
+
+    private final String preDeclarations;
+    private final List<String> languageModifiers;
+    private final String name;
+    private final String languageParameters;
+    private final String languageDeclarations;
+    private final List<Event> events;
+    private final List<Property> properties;
+
+    /**
+     * Construct the specification out of its children elements.
+     *
+     * @param languageModifiers    Words before the name directing behavior of rv-monitor.
+     * @param name                 The name of the specification.
+     * @param languageParameters   Parameters used to parameterize the monitor.
+     * @param languageDeclarations Language-specific declarations used in the monitoring code.
+     * @param events               The events to monitor in the code.
+     * @param properties           Properties and handlers on the sequence of events.
+     */
+    public Specification(final String preDeclarations,
+                         final List<String> languageModifiers, final String name,
+                         final String languageParameters, final String languageDeclarations,
+                         final List<Event> events, final List<Property> properties) {
+        this.preDeclarations = preDeclarations;
+        this.languageModifiers = Collections
+                .unmodifiableList(new ArrayList<String>(languageModifiers));
+        this.name = name;
+        this.languageParameters = languageParameters;
+        this.languageDeclarations = languageDeclarations;
+        this.events = Collections
+                .unmodifiableList(new ArrayList<javamop.parser.rvm.core.ast.Event>(events));
+        this.properties = Collections.unmodifiableList(new ArrayList<Property>(
+                properties));
+    }
+
+    /**
+     * An unmodifiable list of words used to affect the code generator.
+     *
+     * @return Words affecting the code generator.
+     */
+    public List<String> getLanguageModifiers() {
+        return languageModifiers;
+    }
+
+    /**
+     * The name of the specification/monitor.
+     *
+     * @return The name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Variables used to parameterize the monitor, if any.
+     *
+     * @return The monitor parameters.
+     */
+    public String getLanguageParameters() {
+        return languageParameters;
+    }
+
+    /**
+     * Language-specific declarations used inside the monitor.
+     *
+     * @return Declarations used by the monitor written in the target language.
+     */
+    public String getLanguageDeclarations() {
+        return languageDeclarations;
+    }
+
+    /**
+     * An unmodifiable list with the events to monitor.
+     *
+     * @return The events being monitored by the generated monitor program.
+     */
+    public List<javamop.parser.rvm.core.ast.Event> getEvents() {
+        return events;
+    }
+
+    /**
+     * An unmodifiable list with the logic properties and their handlers.
+     *
+     * @return The properties with their handlers of the specification.
+     */
+    public List<Property> getProperties() {
+        return properties;
+    }
+
+}

--- a/src/main/java/javamop/util/Tool.java
+++ b/src/main/java/javamop/util/Tool.java
@@ -2,6 +2,8 @@
 package javamop.util;
 
 
+import org.apache.commons.io.FileUtils;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -289,41 +291,13 @@ public final class Tool {
     }
 
     /**
-     * Delete a directory and all its contents. Every file has to be individually deleted, since
-     * there is no built-in java function to delete an entire directory and its contents
-     * recursively.
+     * Delete a directory and all its contents.
      *
      * @param path The path of the directory to delete.
-     * @throws java.io.IOException If it cannot traverse the directories or the files cannot be deleted.
+     * @throws java.io.IOException If the underlying FileUtils throws IOException.
      */
     public static void deleteDirectory(final Path path) throws IOException {
         // http://stackoverflow.com/a/8685959
-        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                // try to delete the file anyway, even if its attributes
-                // could not be read, since delete-only access is
-                // theoretically possible
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                if (exc == null) {
-                    Files.delete(dir);
-                    return FileVisitResult.CONTINUE;
-                } else {
-                    // directory iteration failed; propagate exception
-                    throw exc;
-                }
-            }
-        });
+        FileUtils.deleteDirectory(path.toFile());
     }
 }

--- a/src/main/javacc/javamop/parser/main_parser/RVParser.jj
+++ b/src/main/javacc/javamop/parser/main_parser/RVParser.jj
@@ -90,7 +90,7 @@ public class RVParser {
     }
     
     /**
-     * Reads a segment from the character stream with matching open and close characters, 
+     * Reads a segment from the character stream with matching open and close characters,
      * e.g. (((--)--(--))--).
      * @param open The opening character.
      * @param close The closing character.
@@ -100,6 +100,9 @@ public class RVParser {
     private String parseMatchingSegment(final char open, final char close, int depth)
             throws ParseException {
         try {
+            boolean inStr = false;
+            boolean escaped = false;
+
             StringBuilder innerSegment = new StringBuilder();
             for(int i = 0; i < depth; i++) {
                 innerSegment.append(open);
@@ -107,6 +110,20 @@ public class RVParser {
             while(depth > 0) {
                 char c = jj_input_stream.readChar();
                 innerSegment.append(c);
+                if (escaped) {
+                    escaped = false;
+                    continue;
+                } else {
+                    if (c == '\\') {
+                        escaped = true;
+                    } else if (c == '"'){
+                        inStr = !inStr; //flip the state of inStr
+                    }
+                }
+
+                if (inStr)  //the curly braces inside string should not be counted.
+                    continue;
+
                 if(c == open) {
                     depth++;
                 } else if(c == close) {
@@ -119,7 +136,7 @@ public class RVParser {
             return "";
         }
     }
-    
+
     /**
      * Parse matching parentheses from the character stream, assuming one is already read.
      * @return The string read, including the first and last parentheses.

--- a/src/main/javacc/javamop/parser/main_parser/RVParser.jj
+++ b/src/main/javacc/javamop/parser/main_parser/RVParser.jj
@@ -1,0 +1,328 @@
+options {
+ STATIC = false;
+}
+
+PARSER_BEGIN(RVParser)
+package javamop.parser.main_parser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.io.*;
+
+import javamop.parser.rvm.core.ast.Event;
+import javamop.parser.rvm.core.ast.MonitorFile;
+import javamop.parser.rvm.core.ast.Property;
+import javamop.parser.rvm.core.ast.PropertyHandler;
+import javamop.parser.rvm.core.ast.Specification;
+
+/**
+ * Language-agnostic RVM file parser.
+ * @author A. Cody Schuffelen
+ */
+public class RVParser {
+    
+    /**
+     * Parse a complete RVM file specification.
+     * @param s The text of the file.
+     * @return The parsed file as a Java object.
+     */
+    public static MonitorFile parse(final String s) {
+        return parse(new BufferedReader(new StringReader(s)));
+    }
+    
+    /**
+     * Parse a complete RVM file specification.
+     * @param reader The place to read the specification from.
+     * @return The parsed file as a Java object.
+     */
+    public static MonitorFile parse(final Reader reader) {
+        RVParser parser = new RVParser(reader);
+        try {
+            return parser.rvmFile();
+        } catch(ParseException e) {
+            throw new RuntimeException(e);
+        } catch(TokenMgrError e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    /**
+     * Read a backtick segment with matched backticks, e.g. `a`, ``a``, ```a```, or ``a`b``.
+     * Assumes the first backtick has already been read.
+     * @return The text inside the backticks.
+     */
+    private String parseBacktickSegment() throws ParseException {
+        try {
+            int backtickDepth = 1;
+            char c;
+            while((c =jj_input_stream.readChar()) == '`') {
+                backtickDepth++;
+            }
+            StringBuilder innerSegment = new StringBuilder();
+            innerSegment.append(c);
+            while(true) {
+                while((c = jj_input_stream.readChar()) != '`') {
+                    innerSegment.append(c);
+                }
+                int endingTicks;
+                for(endingTicks = 1; endingTicks < backtickDepth; endingTicks++) {
+                    c = jj_input_stream.readChar();
+                    if(c != '`') {
+                        for(int i = 0; i < endingTicks; i++) {
+                            innerSegment.append('`');
+                        }
+                        innerSegment.append(c);
+                        break;
+                    }
+                }
+                if(endingTicks == backtickDepth) {
+                    return innerSegment.toString();
+                }
+            }
+        } catch(IOException ioe) {
+            ioe.printStackTrace();
+            return "";
+        }
+    }
+    
+    /**
+     * Reads a segment from the character stream with matching open and close characters, 
+     * e.g. (((--)--(--))--).
+     * @param open The opening character.
+     * @param close The closing character.
+     * @param depth The number of open parentheses already parsed.
+     * @return The full text, including the first open and close parentheses.
+     */
+    private String parseMatchingSegment(final char open, final char close, int depth)
+            throws ParseException {
+        try {
+            StringBuilder innerSegment = new StringBuilder();
+            for(int i = 0; i < depth; i++) {
+                innerSegment.append(open);
+            }
+            while(depth > 0) {
+                char c = jj_input_stream.readChar();
+                innerSegment.append(c);
+                if(c == open) {
+                    depth++;
+                } else if(c == close) {
+                    depth--;
+                }
+            }
+            return innerSegment.toString();
+        } catch(IOException ioe) {
+            ioe.printStackTrace();
+            return "";
+        }
+    }
+    
+    /**
+     * Parse matching parentheses from the character stream, assuming one is already read.
+     * @return The string read, including the first and last parentheses.
+     */
+    private String parseMatchingParens() throws ParseException {
+        return parseMatchingSegment('(', ')', 1);
+    }
+    
+    /**
+     * Parse matching curly brackets from the character stream, assuming one is already read.
+     * @return The string read, including the first and last curly brackets.
+     */
+    private String parseMatchingCurlyBrackets() throws ParseException {
+        return parseMatchingSegment('{', '}', 1);
+    }
+    
+    /**
+     * Read characters from the character stream until a string is exactly matched. Pushes the
+     * matched text back onto the character stream.
+     * @param end The string to match.
+     * @return All the text until the matched string.
+     */
+    private String parseUntil(final String end) throws ParseException {
+        try {
+            StringBuilder innerSegment = new StringBuilder();
+            while(true) {
+                char c;
+                while((c = jj_input_stream.readChar()) != end.charAt(0)) {
+                    innerSegment.append(c);
+                }
+                StringBuilder partialMatch = new StringBuilder();
+                partialMatch.append(c);
+                for(int i = 1; i < end.length(); i++) {
+                    c = jj_input_stream.readChar();
+                    if(c == end.charAt(i)) {
+                        partialMatch.append(c);
+                    } else {
+                        break;
+                    }
+                }
+                if(partialMatch.toString().equals(end)) {
+                    jj_input_stream.backup(end.length());
+                    return innerSegment.toString();
+                } else {
+                    innerSegment.append(partialMatch);
+                }
+            }
+        } catch(IOException ioe) {
+            ioe.printStackTrace();
+            return "";
+        }
+    }
+    
+    /**
+     * Read lines from the character stream until a regular expression matches the line. Pushes
+     * the matching line back into the character stream.
+     * @param pattern The regular expression to match against each line.
+     * @return The text until the matching line.
+     */
+    private String parseUntilLineMatches(final Pattern pattern) {
+        try {
+            StringBuilder allText = new StringBuilder();
+            StringBuilder line = new StringBuilder();
+            while(!pattern.matcher(line.toString()).find()) {
+                allText.append(line);
+                line = new StringBuilder();
+                char c;
+                while((c = jj_input_stream.readChar()) != '\n') {
+                    line.append(c);
+                }
+                line.append(c);
+            }
+            jj_input_stream.backup(line.length());
+            return allText.toString();
+        } catch(IOException ioe) {
+            ioe.printStackTrace();
+            return "";
+        }
+    }
+}
+PARSER_END(RVParser)
+
+SKIP : {
+    <WHITESPACE: [" ","\t","\r","\n"]>
+    | <LINECOMMENT: "//" (~["\n"])* "\n">
+    | <BLOCKCOMMENT: "/*"(~["*"])* "*"(~["/"] (~["*"])* "*")* "/" >
+}
+
+TOKEN : {
+    <LBRACE : "{">
+    | <RBRACE : "}">
+    | <LPAREN : "(">
+    | <RPAREN : ")">
+    | <COLON : ":">
+    | <AT : "@">
+    | <EVENT : ("event")>
+    | <ID : (<LETTER>|"_")(<LETTER>|<DIGIT>|"_"|"."|"-")*>
+    | <DIGIT : ["0"-"9"]>
+    | <LETTER : ["a"-"z","A"-"Z"]>
+    | <BACKTICK : "`">
+}
+
+MonitorFile rvmFile() : {
+    String preamble;
+    ArrayList<Specification> specs = new ArrayList<Specification>();
+    Specification spec;
+}
+{
+    {preamble = parseUntilLineMatches(Pattern.compile("^([0-9_a-zA-Z\\s-]+)((\\()|(\\{))"));}
+    (spec = specification() { specs.add(spec); })+
+    {
+        return new MonitorFile(preamble, specs);
+    }
+}
+
+Specification specification() : {
+    String preDeclarations = "";
+    ArrayList<String> languageModifiers = new ArrayList<String>();
+    Token modifier;
+    String languageParameters = "";
+    String languageDeclarations = "";
+    ArrayList<Event> events = new ArrayList<Event>();
+    Event myEvent;
+    ArrayList<Property> properties = new ArrayList<Property>();
+    Property myProperty;
+}
+{
+    (modifier = <ID> {languageModifiers.add(modifier.image);})+
+    (languageParameters = delimitedNoCurly())?
+    "{"
+        {languageDeclarations = parseUntilLineMatches(Pattern.compile(
+            "^([-a-zA-Z\\s_]*)event([a-zA-Z_\\s0-9]+)\\("));}
+        (LOOKAHEAD( 2 ) myEvent = event() { events.add(myEvent); })+
+        (myProperty = propertyAndHandlers() {properties.add(myProperty);})*
+    "}"
+    {
+        String name = languageModifiers.get(languageModifiers.size() - 1);
+        languageModifiers.remove(languageModifiers.size() - 1);
+        return new Specification(preDeclarations, languageModifiers, name, languageParameters,
+            languageDeclarations, events, properties);
+    }
+}
+
+Event event() : {
+    ArrayList<String> modifiers = new ArrayList<String>();
+    Token modifier;
+    Token name;
+    ArrayList<String> definitionModifiers = new ArrayList<String>();
+    Token definitionModifier;
+    String eventDefinition = "";
+    String eventPointcut = "";
+    String eventAction = "";
+}
+{
+    (modifier = <ID> { modifiers.add(modifier.image); })*
+    <EVENT>
+    (name = <ID>)
+    (definitionModifier = <ID> { definitionModifiers.add(definitionModifier.image); })*
+    (eventDefinition = delimitedSegment())
+    {eventPointcut = parseUntil("{");}
+    "{" {eventAction = parseMatchingCurlyBrackets();}
+    {return new Event(modifiers, name.image, definitionModifiers, eventDefinition, eventPointcut, 
+        eventAction);}
+}
+
+Property propertyAndHandlers() : {
+    Token name;
+    Token notAt;
+    String syntax = "";
+    ArrayList<PropertyHandler> propertyHandlers = new ArrayList<PropertyHandler>();
+    PropertyHandler handler;
+}
+{
+    (name = <ID>)
+    ":"
+    {syntax = parseUntil("@");}
+    (handler = propertyHandler() {propertyHandlers.add(handler);})+
+    {return new Property(name.image, syntax, propertyHandlers);}
+}
+
+PropertyHandler propertyHandler() : {
+    Token name;
+    String languageAction = "";
+}
+{
+    "@"
+    (name = <ID>)
+    (languageAction = delimitedSegment())
+    {return new PropertyHandler(name.image, languageAction);}
+}
+
+String delimitedSegment() : {
+    String other;
+}
+{
+    (other = delimitedNoCurly() { return other; }) |
+    ("{" { return parseMatchingCurlyBrackets(); })
+}
+
+String delimitedNoCurly() : {
+
+}
+{
+    ("`" { return parseBacktickSegment(); }) |
+    ("(" { return parseMatchingParens(); })
+}

--- a/src/test/java/baseaspect/BaseAspectIT.java
+++ b/src/test/java/baseaspect/BaseAspectIT.java
@@ -154,7 +154,7 @@ public class BaseAspectIT {
                     "com.runtimeverification.rvmonitor.java.rvj.Main",
                     "-d", ".", rvmFile);
 
-            // AJC has nonzero return codes with just warnings, not errorss.
+            // AJC has nonzero return codes with just warnings, not errors.
             //First, test whether Has_Next.java was instrumented as usual
             helper_userSpecified.testCommand(null, false, true, "java",
                     "org.aspectj.tools.ajc.Main", "-1.6", "-d", prefix1,

--- a/src/test/java/baseaspect/BaseAspectIT.java
+++ b/src/test/java/baseaspect/BaseAspectIT.java
@@ -85,7 +85,7 @@ public class BaseAspectIT {
                     "com.runtimeverification.rvmonitor.java.rvj.Main",
                     "-d", ".", rvmFile);
 
-            // AJC has nonzero return codes with just warnings, not errorss.
+            // AJC has nonzero return codes with just warnings, not errors.
             helper_default.testCommand(null, false, true, "java",
                     "org.aspectj.tools.ajc.Main", "-1.6", "-d", javaOutputPrefix,
                     javaOutputPrefix + File.separator + javaOutputPrefix + ".java",


### PR DESCRIPTION
Try to remove the rv-monitor dependency.
The first step is simply to copy all the required files from rv-monitor side to javamop.
The functionality and structure of the code will be analyzed in the next step to avoid duplication.
The docs should also be updated to reflect the fact that no rv-monitor is needed to run javamop.