### PR TITLE
Fix "Building a JavaMOP Agent" tutorial step

### DIFF
--- a/docs/JavaMOPAgentUsage.md
+++ b/docs/JavaMOPAgentUsage.md
@@ -48,7 +48,7 @@ property files: SafeFile.mop and SafeFileWriter.mop.
    After this step, these files will be generated:
    `MultiSpec_1MonitorAspect.aj`, `SafeFile.rvm` and `SafeFileWriter.rvm`):
 
-	```javamop -merge *.mop```
+	```javamop -merge -keepRVFiles *.mop```
 
 5. Create directories for storing the monitor libraries:
 


### PR DESCRIPTION
Fix the javamop command of "Building a JavaMOP Agent" tutorial to keep
the generated .rvm files

Javamop command deletes the generated .rvm files unless it's told
otherwise and since rv-monitor uses said files to generate the resulting
.java with the instrumented properties, it's absolutely necessary
that they are kept for the rv-monitor step.