### PR TITLE
Support Generics in Advice arguments

### DIFF
--- a/src/main/javacc/javamop/parser/main_parser/javamop.jj
+++ b/src/main/javacc/javamop/parser/main_parser/javamop.jj
@@ -181,6 +181,25 @@ public final class JavaMOPParser {
     	return buf.toString().trim();
     }
 
+    private String toTypeArgsString(List<Type> typeArgs) {
+        if(typeArgs == null) {
+            return "";
+        }
+
+        int i = 0;
+        String typeArgString = "<";
+        for(Type typeArg : typeArgs) {
+            if(i == 0) {
+               typeArgString += typeArg.toString();
+            } else {
+               typeArgString += ", " + typeArg.toString();
+            }
+            i += 1;
+        }
+        typeArgString += ">";
+        return typeArgString;
+    }
+
 	private class Modifier {
 		
 		final int modifiers;
@@ -1348,6 +1367,7 @@ List<MOPParameter> MOPParameters():
   { return parameters; }
 }
 
+// TODO: This class is redundant. Needs cleanup.
 List<MOPParameter> AdviceParameters():
 {
 	List<MOPParameter> parameters = new ArrayList<MOPParameter>();
@@ -1458,10 +1478,15 @@ BaseTypePattern SimpleTypePattern():
 {
 	String id;
 	int line, column;
+	List<Type> typeArgs = null;
 }
 {
 	(<IDENTIFIER> | "get" | "set" ) {line = token.beginLine; column = token.beginColumn; id = token.image;}
-	("." {id += token.image;} (<IDENTIFIER> | "get" | "set") {id += token.image;})*
+	[LOOKAHEAD(2) typeArgs = TypeArguments() ] { id += toTypeArgsString(typeArgs); typeArgs = null;}
+	(
+	    LOOKAHEAD(2) "." (<IDENTIFIER> | "get" | "set") {id += "." + token.image;}
+	    [ LOOKAHEAD(2) typeArgs = TypeArguments() ] {id += toTypeArgsString(typeArgs); typeArgs = null;}
+	)*
 	("[" {id += token.image;} "]" {id += token.image;})*
 	["+" {id += token.image;}]
 	{ return new BaseTypePattern(line, column, id); }
@@ -1472,13 +1497,18 @@ BaseTypePattern TypePattern():
 {
 	String id;
 	int line, column;
+	List<Type> typeArgs = null;
 }
 {    
 	(<IDENTIFIER> | "get"| "set" | "byte" | "short" | "int" 
          | "long" | "float" | "double" | "boolean" | "char") 
-        { 
+        {
           line = token.beginLine; column = token.beginColumn; id = token.image;}
-	("." {id += token.image;} (<IDENTIFIER> | "get" | "set") {id += token.image;})*
+	[LOOKAHEAD(2) typeArgs = TypeArguments() ] { id += toTypeArgsString(typeArgs); typeArgs = null;}
+	(
+	    LOOKAHEAD(2) "." (<IDENTIFIER> | "get" | "set") {id += "." + token.image;}
+	    [ LOOKAHEAD(2) typeArgs = TypeArguments() ] {id += toTypeArgsString(typeArgs); typeArgs = null;}
+	)*
 	("[" {id += token.image;} "]" {id += token.image;})*
 	["+" {id += token.image;}]
 	{ return new BaseTypePattern(line, column, id); }

--- a/src/test/java/unit/javamop/parser/AdviceParamsWithGenericsTest.java
+++ b/src/test/java/unit/javamop/parser/AdviceParamsWithGenericsTest.java
@@ -1,0 +1,121 @@
+package unit.javamop.parser;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import javamop.parser.ast.mopspec.MOPParameters;
+import javamop.parser.astex.MOPSpecFileExt;
+import javamop.parser.astex.mopspec.EventDefinitionExt;
+import javamop.parser.astex.mopspec.JavaMOPSpecExt;
+import javamop.parser.main_parser.JavaMOPParser;
+import javamop.parser.main_parser.ParseException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AdviceParamsWithGenericsTest {
+
+    private static final String errIncorrectArgNum = "Unexpected number of parameters";
+    private static final String errIncorrectGenericType = "Unexpected number of parameters";
+
+
+    private InputStream fromResources(Path filePath) {
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        return classLoader.getResourceAsStream(filePath.toString());
+    }
+
+    private EventDefinitionExt getEvent(String folder, String name) {
+        MOPSpecFileExt parsedFile = null;
+        try {
+            parsedFile = JavaMOPParser.parse(fromResources(Paths.get(folder, name)));
+            assertNotNull("Parser neither parsed file nor threw exception", parsedFile);
+
+        } catch (ParseException e) {
+            fail("Unexpected ParseException" + e.getMessage());
+        }
+
+        List<JavaMOPSpecExt> specs = parsedFile.getSpecs();
+        assertEquals("Unexpected number of Spec ASTs", 1, specs.size());
+        JavaMOPSpecExt spec = specs.get(0);
+
+        List<EventDefinitionExt> events = spec.getEvents();
+        assertEquals("Unexpected number of Event ASTs", 1, events.size());
+
+        return events.get(0);
+    }
+
+
+    @Test
+    public void singleBasicParamTest() {
+        EventDefinitionExt event = getEvent("single-property", "AdviceParamsWithGenericsBasic.mop");
+        MOPParameters adviceParams = event.getMOPParameters();
+
+        assertEquals(errIncorrectArgNum, 1, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                    , "List<Foo>"
+                    , adviceParams.get(0).getType().toString());
+    }
+
+    @Test
+    public void multipleBasicParamsTest() {
+        EventDefinitionExt event = getEvent("single-property", "AdviceParamsWithGenericsMultipleBasic.mop");
+        MOPParameters adviceParams = event.getMOPParameters();
+
+        assertEquals(errIncorrectArgNum, 2, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                    , "List<Foo>"
+                    , adviceParams.get(0).getType().toString());
+
+        assertEquals(errIncorrectGenericType
+                    , "List<Bar>"
+                    , adviceParams.get(1).getType().toString());
+    }
+
+    @Test
+    public void singleNestedParamTest() {
+        EventDefinitionExt event = getEvent("single-property", "AdviceParamsWithGenericsNested.mop");
+        MOPParameters adviceParams = event.getMOPParameters();
+
+        assertEquals(errIncorrectArgNum, 1, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                    , "List<Map<List<Foo>>>"
+                    , adviceParams.get(0).getType().toString());
+    }
+
+
+    @Test
+    public void multipleNestedParamsTest() {
+        EventDefinitionExt event = getEvent("single-property", "AdviceParamsWithGenericsMultipleNested.mop");
+        MOPParameters adviceParams = event.getMOPParameters();
+
+        assertEquals(errIncorrectArgNum, 2, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                    , "List<Map<List<Foo>>>"
+                    , adviceParams.get(0).getType().toString());
+
+        assertEquals(errIncorrectGenericType
+                    , "List<Map<List<Bar>>>"
+                    , adviceParams.get(1).getType().toString());
+    }
+
+    @Test
+    public void singleWildcardParamTest() {
+        EventDefinitionExt event = getEvent("single-property", "AdviceParamsWithGenericsWildcard.mop");
+        MOPParameters adviceParams = event.getMOPParameters();
+
+        assertEquals(errIncorrectArgNum, 1, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                    , "List<? extends Foo<Buzz>>"
+                    , adviceParams.get(0).getType().toString());
+    }
+
+    @Test(expected = ParseException.class)
+    public void illegalParamsTest() throws ParseException{
+        JavaMOPParser.parse(fromResources(Paths.get( "single-property"
+                                                   , "AdviceParamsWithGenericsIllegal.mop")));
+    }
+
+}

--- a/src/test/java/unit/javamop/parser/AdviceParamsWithGenericsTest.java
+++ b/src/test/java/unit/javamop/parser/AdviceParamsWithGenericsTest.java
@@ -20,7 +20,6 @@ public class AdviceParamsWithGenericsTest {
     private static final String errIncorrectArgNum = "Unexpected number of parameters";
     private static final String errIncorrectGenericType = "Unexpected number of parameters";
 
-
     private InputStream fromResources(Path filePath) {
         ClassLoader classLoader = getClass().getClassLoader();
 

--- a/src/test/resources/single-property/AdviceParamsWithGenericsBasic.mop
+++ b/src/test/resources/single-property/AdviceParamsWithGenericsBasic.mop
@@ -1,0 +1,18 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsBasic() {
+
+        event basicGeneric before(List<Foo> foo):
+              call(* bar(..)) && args(foo) {}
+
+        ere : basicGeneric
+
+        @match {
+           System.out.println("basic generics test");
+        }
+
+}
+

--- a/src/test/resources/single-property/AdviceParamsWithGenericsIllegal.mop
+++ b/src/test/resources/single-property/AdviceParamsWithGenericsIllegal.mop
@@ -1,0 +1,17 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsIllegal() {
+
+        event basicGeneric before(List<fizz<> foo):
+              call(* bar(..)) && target(foo) {}
+
+        ere : basicGeneric
+
+        @match {
+           System.out.println("illegal generics test");
+        }
+
+}

--- a/src/test/resources/single-property/AdviceParamsWithGenericsMultipleBasic.mop
+++ b/src/test/resources/single-property/AdviceParamsWithGenericsMultipleBasic.mop
@@ -1,0 +1,17 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsMultipleBasic() {
+
+        event basicGeneric before(List<Foo> foo, List<Bar> bar):
+              call(* bar(..)) && args(foo, bar) {}
+
+        ere : basicGeneric
+
+        @match {
+           System.out.println("basic generics test");
+        }
+
+}

--- a/src/test/resources/single-property/AdviceParamsWithGenericsMultipleNested.mop
+++ b/src/test/resources/single-property/AdviceParamsWithGenericsMultipleNested.mop
@@ -1,0 +1,17 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsMultipleNested() {
+
+        event basicGeneric before(List<Map<List<Foo>>> foo, List<Map<List<Bar>>> bar):
+              call(* buzz(..)) && args(foo, bar) {}
+
+        ere : basicGeneric
+
+        @match {
+           System.out.println("basic generics test");
+        }
+
+}

--- a/src/test/resources/single-property/AdviceParamsWithGenericsNested.mop
+++ b/src/test/resources/single-property/AdviceParamsWithGenericsNested.mop
@@ -1,0 +1,17 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsNested() {
+
+        event basicGeneric before(List<Map<List<Foo>>> foo):
+              call(* bar(..)) && args(foo) {}
+
+        ere : basicGeneric
+
+        @match {
+           System.out.println("basic generics test");
+        }
+
+}

--- a/src/test/resources/single-property/AdviceParamsWithGenericsWildcard.mop
+++ b/src/test/resources/single-property/AdviceParamsWithGenericsWildcard.mop
@@ -1,0 +1,17 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsWildcard() {
+
+        event basicGeneric before(List<? extends Foo<Buzz>> bar):
+              call(* fun(..)) && target(bar) {}
+
+        ere : basicGeneric
+
+        @match {
+           System.out.println("illegal generics test");
+        }
+
+}


### PR DESCRIPTION
Allows parsing advice arguments like `event foo(List<TypeBar> argBuzz)`
